### PR TITLE
Add Homebrew cask

### DIFF
--- a/Casks/nofwl.rb
+++ b/Casks/nofwl.rb
@@ -1,0 +1,27 @@
+cask "nofwl" do
+  arch arm: "aarch64", intel: "x86_64"
+
+  version "0.1.0"
+  sha256 arm:   "dddf534069abb9445022aa5a3c157bb2565a165cd82d32c51fa9cc118162e128",
+         intel: "19b5c1daebf6e954ebd72c5c162da00a3f6a2b9a305e23a9a8dc1cd7e5ee03a4"
+
+  url "https://github.com/lencx/nofwl/releases/download/v#{version}/NoFWL_#{version}_macos_#{arch}.dmg"
+  name "NoFWL"
+  desc "Desktop application"
+  homepage "https://github.com/lencx/nofwl"
+
+  livecheck do
+    url :homepage
+    strategy :github_latest
+  end
+
+  app "NoFWL.app"
+
+  zap trash: [
+    "~/.nofwl",
+    "~/Library/Caches/com.nofwl.app",
+    "~/Library/Preferences/com.nofwl.app.plist",
+    "~/Library/Saved Application State/com.nofwl.app.savedState",
+    "~/Library/WebKit/com.nofwl.app",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ Currently under active development, please be patient. Its development is inspir
 
 - [NoFWL_0.1.0_macos_aarch64.dmg](https://github.com/lencx/nofwl/releases/download/v0.1.0/NoFWL_0.1.0_macos_aarch64.dmg): Direct download installer
 - [NoFWL_0.1.0_macos_x86_64.dmg](https://github.com/lencx/nofwl/releases/download/v0.1.0/NoFWL_0.1.0_macos_x86_64.dmg): Direct download installer
+- Homebrew \
+  Or you can install with _[Homebrew](https://brew.sh) ([Cask](https://docs.brew.sh/Cask-Cookbook)):_
+  ```sh
+  brew tap lencx/nofwl https://github.com/lencx/nofwl.git
+  brew install --cask nofwl --no-quarantine
+  ```
+  Also, if you keep a _[Brewfile](https://github.com/Homebrew/homebrew-bundle#usage)_, you can add something like this:
+  ```rb
+  repo = "lencx/nofwl"
+  tap repo, "https://github.com/#{repo}.git"
+  cask "nofwl", args: { "no-quarantine": true }
+  ```
+
 
 #### Developer cannot be verified?
 


### PR DESCRIPTION
Add Cask nofwl.rb and update README.md with instructions on installing.

I would recommend moving the cask to a separate repository `lencx/homebrew-nofwl'. It would simplify the tap command and make updating the cask easier. The cask is otherwise in-line with the Cask cookbook.