### PR TITLE
Add Chocolatey install method to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Currently under active development, please be patient. Its development is inspir
 
 ### Windows
 
-[NoFWL_0.1.0_windows_x86_64.msi](https://github.com/lencx/nofwl/releases/download/v0.1.0/NoFWL_0.1.0_windows_x86_64.msi): Direct download installer
+- [NoFWL_0.1.0_windows_x86_64.msi](https://github.com/lencx/nofwl/releases/download/v0.1.0/NoFWL_0.1.0_windows_x86_64.msi): Direct download installer
 - Use [Chocolatey](https://community.chocolatey.org/packages/nofwl):
   ```bash
   # install the latest version

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ Currently under active development, please be patient. Its development is inspir
 ### Windows
 
 [NoFWL_0.1.0_windows_x86_64.msi](https://github.com/lencx/nofwl/releases/download/v0.1.0/NoFWL_0.1.0_windows_x86_64.msi): Direct download installer
+- Use [Chocolatey](https://community.chocolatey.org/packages/nofwl):
+  ```bash
+  # install the latest version
+  choco install nofwl -y
+  ```
 
 ### macOS
 


### PR DESCRIPTION
Added a way to install the nofwl package using the Chocolatey community repository (https://community.chocolatey.org/packages/nofwl). Each package is validated, verified, and virus scanned. 